### PR TITLE
Fixing issues with collection data and query parameters containing single quotes

### DIFF
--- a/src/JohannesSchobel/DingoQueryMapper/Operators/CollectionOperator.php
+++ b/src/JohannesSchobel/DingoQueryMapper/Operators/CollectionOperator.php
@@ -118,6 +118,10 @@ class CollectionOperator implements Operations
         if ($operator == '=') {
             $operator = '==';
         }
+
+        // escaping
+        $key = str_replace("'", "\'", $key);
+
         $rule = "'%s' %s '%s'"; // key, operator, value
         $rule = sprintf($rule, $key, $operator, $value);
 

--- a/src/JohannesSchobel/DingoQueryMapper/Parser/UriParser.php
+++ b/src/JohannesSchobel/DingoQueryMapper/Parser/UriParser.php
@@ -113,7 +113,10 @@ class UriParser
      * @param $query
      */
     private function setQueryParameters($query)
-    {
+    {   
+        // escaping
+        $query = str_replace("'", "\'", $query);
+        
         $queryParameters = array_filter(explode('&', $query));
 
         array_map([$this, 'appendQueryParameter'], $queryParameters);


### PR DESCRIPTION
This is a suggestion to fix #12. 

While looking into this I also found out that passing single quotes text as query parameters is breaking things. Therefore I added escaping to the `setQueryParameters` method as well.