### PR TITLE
Add slashes to query parameters and filter rules

### DIFF
--- a/src/JohannesSchobel/DingoQueryMapper/Operators/CollectionOperator.php
+++ b/src/JohannesSchobel/DingoQueryMapper/Operators/CollectionOperator.php
@@ -118,6 +118,10 @@ class CollectionOperator implements Operations
         if ($operator == '=') {
             $operator = '==';
         }
+
+        // escaping
+        $key = addslashes($key);
+
         $rule = "'%s' %s '%s'"; // key, operator, value
         $rule = sprintf($rule, $key, $operator, $value);
 

--- a/src/JohannesSchobel/DingoQueryMapper/Parser/UriParser.php
+++ b/src/JohannesSchobel/DingoQueryMapper/Parser/UriParser.php
@@ -114,6 +114,9 @@ class UriParser
      */
     private function setQueryParameters($query)
     {
+        // escaping
+        $query = addslashes($query);
+
         $queryParameters = array_filter(explode('&', $query));
 
         array_map([$this, 'appendQueryParameter'], $queryParameters);


### PR DESCRIPTION
Should now, a bit more elegant, fix #12.