### PR TITLE
changed sorting to be case insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ will return the next `20` entries that are located on `page 2`.
 
 
 ### `sort`
-In order to sort the results using different parameters, you can simply concatenate them using `,`. In order to provide `ASC` and `DESC` sorting, you may prepend a `-` before respective attribute.
+In order to sort the results using different parameters, you can simply concatenate them using `,`. In order to provide `ASC` and `DESC` sorting, you may prepend a `-` before respective attribute. Sorting is case-insensitive.
 
 For example
 ```php

--- a/src/JohannesSchobel/DingoQueryMapper/Operators/CollectionOperator.php
+++ b/src/JohannesSchobel/DingoQueryMapper/Operators/CollectionOperator.php
@@ -68,9 +68,9 @@ class CollectionOperator implements Operations
             foreach ($criteria as $c) {
                 // normalize sort direction
                 $orderType = strtolower($c['direction']);
-                if ($first[$c['column']] < $second[$c['column']]) {
+                if (strtolower($first[$c['column']]) < strtolower($second[$c['column']])) {
                     return $orderType === "asc" ? -1 : 1;
-                } elseif ($first[$c['column']] > $second[$c['column']]) {
+                } elseif (strtolower($first[$c['column']]) > strtolower($second[$c['column']])) {
                     return $orderType === "asc" ? 1 : -1;
                 }
             }


### PR DESCRIPTION
In order to avoid A-Z being sorted before a-z, strings are compared using `strtolower`.